### PR TITLE
Add proper handling of invalid createConsent request bodies

### DIFF
--- a/api/consent-logic.impl.go
+++ b/api/consent-logic.impl.go
@@ -41,9 +41,7 @@ func (wrapper Wrapper) CreateOrUpdateConsent(ctx echo.Context) error {
 
 	// Validate if the request has at least one record
 	if len(createConsentApiRequest.Records) < 1 {
-		err := errors.New("the consent requires at least one record")
-		ctx.Logger().Error(err)
-		return err
+		return echo.NewHTTPError(http.StatusBadRequest, "the consent requires at least one record")
 	}
 
 	nullTime := time.Time{}

--- a/api/consent-logic.impl_test.go
+++ b/api/consent-logic.impl_test.go
@@ -21,6 +21,7 @@ package api
 import (
 	"encoding/json"
 	"github.com/golang/mock/gomock"
+	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-consent-logic/pkg"
 	cryptomock "github.com/nuts-foundation/nuts-crypto/mock"
 	crypto "github.com/nuts-foundation/nuts-crypto/pkg"
@@ -32,6 +33,7 @@ import (
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 	"time"
@@ -99,6 +101,19 @@ func TestApiResource_NutsConsentLogicCreateConsent(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+	t.Run("It handles an empty request body", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		apiWrapper := Wrapper{}
+		echoServer := mock.NewMockContext(ctrl)
+		echoServer.EXPECT().Bind(gomock.Any()).Do(func(f interface{}) {})
+
+		err := apiWrapper.CreateOrUpdateConsent(echoServer)
+		if assert.Error(t, err) {
+			assert.Equal(t, err.(*echo.HTTPError).Message, "the consent requires at least one record")
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -26,5 +26,6 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 	gopkg.in/thedevsaddam/gojsonq.v2 v2.3.0
 )


### PR DESCRIPTION
Fix #15 

Invalid request bodies resulted in a http status 500. 
This PR fixes that: returning 400 with proper error message.
Better tests are provided to ensure it keeps that way.