### PR TITLE
changed api spec, embedded data changed to document reference

### DIFF
--- a/api/consent-logic.impl.go
+++ b/api/consent-logic.impl.go
@@ -68,8 +68,14 @@ func (wrapper Wrapper) CreateOrUpdateConsent(ctx echo.Context) error {
 		}
 
 		// Validate DataClass
-		if len(record.DataClass) == 0 {
+		if len(record.DataClass) < 1 {
 			return echo.NewHTTPError(http.StatusBadRequest, "the consent record requires at least one data class")
+		}
+
+		for _, dataClass := range record.DataClass {
+			if dataClass == "" {
+				return echo.NewHTTPError(http.StatusBadRequest, "a data class can not be empty")
+			}
 		}
 	}
 

--- a/api/consent-logic.impl_test.go
+++ b/api/consent-logic.impl_test.go
@@ -251,6 +251,27 @@ func TestApiResource_NutsConsentLogicCreateConsent(t *testing.T) {
 		}
 	})
 
+	t.Run("A data class can not be empty", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		apiWrapper := Wrapper{}
+		echoServer := mock.NewMockContext(ctrl)
+
+		jsonRequest := jsonRequest()
+		jsonRequest.Records[0].DataClass = []DataClassification{""}
+		jsonData, _ := json.Marshal(jsonRequest)
+
+		echoServer.EXPECT().Bind(gomock.Any()).Do(func(f interface{}) {
+			_ = json.Unmarshal(jsonData, f)
+		})
+
+		err := apiWrapper.CreateOrUpdateConsent(echoServer)
+		if assert.Error(t, err) {
+			assert.Equal(t, "a data class can not be empty", err.(*echo.HTTPError).Message)
+		}
+	})
+
 }
 
 func Test_apiRequest2Internal(t *testing.T) {

--- a/api/generated.go
+++ b/api/generated.go
@@ -14,13 +14,10 @@ type ActorURI string
 
 // ConsentRecord defines model for ConsentRecord.
 type ConsentRecord struct {
-	ConsentProof struct {
-		// Embedded struct due to allOf(#/components/schemas/EmbeddedData)
-		EmbeddedData
-	} `json:"consentProof"`
-	DataRef          *DataIdentifier `json:"dataRef,omitempty"`
-	Period           Period          `json:"period"`
-	PreviousRecordID *string         `json:"previousRecordID,omitempty"`
+	ConsentProof     DocumentReference    `json:"consentProof"`
+	DataClass        []DataClassification `json:"dataClass"`
+	Period           Period               `json:"period"`
+	PreviousRecordID *string              `json:"previousRecordID,omitempty"`
 }
 
 // CreateConsentRequest defines model for CreateConsentRequest.
@@ -35,16 +32,16 @@ type CreateConsentRequest struct {
 // CustodianURI defines model for CustodianURI.
 type CustodianURI string
 
-// DataIdentifier defines model for DataIdentifier.
-type DataIdentifier struct {
-	DataIdentifier string `json:"dataIdentifier"`
-	EndpointType   string `json:"endpointType"`
-}
+// DataClass defines model for DataClass.
+type DataClassification string
 
-// EmbeddedData defines model for EmbeddedData.
-type EmbeddedData struct {
-	ContentType string `json:"contentType"`
-	Data        string `json:"data"`
+// DocumentReference defines model for DocumentReference.
+type DocumentReference struct {
+	ID          string  `json:"ID"`
+	URL         *string `json:"URL,omitempty"`
+	ContentType *string `json:"contentType,omitempty"`
+	Hash        *string `json:"hash,omitempty"`
+	Title       string  `json:"title"`
 }
 
 // IdentifierURI defines model for IdentifierURI.
@@ -101,3 +98,4 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.POST("/api/consent", wrapper.CreateOrUpdateConsent)
 
 }
+

--- a/docs/_static/nuts-consent-logic.yaml
+++ b/docs/_static/nuts-consent-logic.yaml
@@ -106,19 +106,22 @@ components:
           type: string
           format: date-time
           example: "2019-11-20T17:02:33+10:00"
-    EmbeddedData:
+    DocumentReference:
       type: object
       required:
-        - data
+        - URL
         - contentType
       properties:
-        data:
+        URL:
           type: string
-          description: Base64 encoded data with a content type
-          example: "UGxhaW4gdGV4dCBtZXNzYWdl"
+          description: location where the proof document can be found, should accept Nuts based authentication
+          example: 'https://some.url/path/to/reference.pdf'
         contentType:
           type: string
-          example: 'text/plain'
+          example: 'application/pdf'
+        hash:
+          type: string
+          description: base64 encoded sha256 of the document
     IdentifierURI:
       type: string
       description: "URI defining a party such as a person or organization"
@@ -161,12 +164,13 @@ components:
         - period
       properties:
         consentProof:
-          description: The proof of the consent. E.g. a scan of a signed document, digital signed PDF or irma contract.
+          description: Reference to the proof of the consent. E.g. a scan of a signed document, digital signed PDF or irma contract.
           example:
             contentType: 'application/pdf'
-            data: cGRmIGRvY3VtZW50IHdpdGggc2lnbmF0dXJl
+            URL: 'https://some.url/path/to/reference.pdf'
+            hash: cGRmIGRvY3VtZW50IHdpdGggc2lnbmF0dXJl
           allOf:
-            - $ref: "#/components/schemas/EmbeddedData"
+            - $ref: "#/components/schemas/DocumentReference"
         previousRecordID:
           type: string
           description: |

--- a/docs/_static/nuts-consent-logic.yaml
+++ b/docs/_static/nuts-consent-logic.yaml
@@ -109,9 +109,17 @@ components:
     DocumentReference:
       type: object
       required:
-        - URL
-        - contentType
+        - ID
+        - title
       properties:
+        ID:
+          type: string
+          description: unique identifier useable for retrieving the proof when contacting the care provider (technical or on paper)
+          example: '11112222-2222-3333-4444-555566667777'
+        title:
+          type: string
+          description: 'human readable identifier for consent proof, eg: document name'
+          example: 'Toestemming inzage huisarts.pdf'
         URL:
           type: string
           description: location where the proof document can be found, should accept Nuts based authentication
@@ -138,44 +146,26 @@ components:
       type: string
       description: "URI defining the data subject, usually the patient"
       example: "urn:oid:2.16.840.1.113883.2.4.6.3:999999990"
-    DataIdentifier:
-      type: object
-      required:
-        - endpointType
-        - dataIdentifier
-      properties:
-        endpointType:
-          type: string
-          description: |
-            EndpointType as used by the registry to find the correct endpoint.
-            This value should be used to retrieve the actual endpoint(s) from the registry.
-        dataIdentifier:
-          type: string
-          description: |
-            Unique identifier to retreive the data controlled by this consent in context of the endpointType.
-            For example, if the enpoint type is a http endpoint, this can be the relative path.
-      example:
-        endpointIdentifier: "urn:nuts:endpoint:fhir"
-        dataIdentifier: "/Observation/123"
+    DataClassification:
+      type: string
+      description: 'Nuts classification system identifier'
+      example: 'urn:oid:1.3.6.1.4.1.XXXXX.1.1:MEDICAL'
     ConsentRecord:
       type: object
       required:
         - consentProof
+        - dataClass
         - period
       properties:
         consentProof:
-          description: Reference to the proof of the consent. E.g. a scan of a signed document, digital signed PDF or irma contract.
-          example:
-            contentType: 'application/pdf'
-            URL: 'https://some.url/path/to/reference.pdf'
-            hash: cGRmIGRvY3VtZW50IHdpdGggc2lnbmF0dXJl
-          allOf:
-            - $ref: "#/components/schemas/DocumentReference"
+          $ref: "#/components/schemas/DocumentReference"
         previousRecordID:
           type: string
           description: |
             Optional parameter. If provided, the previous consentRecord will be replaced by this new ConsentRecord.
         period:
           $ref: "#/components/schemas/Period"
-        dataRef:
-          $ref: "#/components/schemas/DataIdentifier"
+        dataClass:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataClassification"

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/thedevsaddam/gojsonq.v2 v2.3.0
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/step-create-fhir-consent-resource_test.go
+++ b/pkg/step-create-fhir-consent-resource_test.go
@@ -20,8 +20,8 @@ package pkg
 
 import (
 	"encoding/json"
+	"gotest.tools/assert"
 	"io/ioutil"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -37,6 +37,9 @@ func TestCreateFhirConsentResource(t *testing.T) {
 	}
 
 	performerId := IdentifierURI("urn:oid:2.16.840.1.113883.2.4.6.1:00000003")
+	url := "https://some.url/reference.pdf"
+	contentType := "application/pdf"
+	hash := "hash"
 
 	endDate := time.Date(2019, time.July, 1, 11, 0, 0, 0, time.UTC)
 
@@ -60,9 +63,16 @@ func TestCreateFhirConsentResource(t *testing.T) {
 							Start: time.Date(2019, time.January, 1, 11, 0, 0, 0, time.UTC),
 							End:   &endDate,
 						},
-						ConsentProof: &EmbeddedData{
-							Data:        "dhklauHAELrlg78OLg==",
-							ContentType: "application/pdf",
+						ConsentProof: &DocumentReference{
+							Title:       "title",
+							ID:          "id",
+							URL:         &url,
+							ContentType: &contentType,
+							Hash:        &hash,
+						},
+						DataClass: []IdentifierURI {
+							IdentifierURI("urn:oid:1.3.6.1.4.1.XXXXX.1:MEDICAL"),
+							IdentifierURI("urn:oid:1.3.6.1.4.1.XXXXX.1:SOCIAL"),
 						},
 					}},
 					Performer: &performerId,
@@ -88,13 +98,8 @@ func TestCreateFhirConsentResource(t *testing.T) {
 				t.Error(err)
 			}
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateFhirConsentResource() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(o1, o2) {
-				t.Errorf("CreateFhirConsentResource() = %v, want %v", o2, o1)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.DeepEqual(t, o1, o2)
 		})
 	}
 }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -38,14 +38,18 @@ type Record struct {
 	RecordID *string
 	// PreviousRecordID refers to a previous record.
 	PreviousRecordID *string
-	ConsentProof     *EmbeddedData
+	ConsentProof     *DocumentReference
+	DataClass        []IdentifierURI
 	Period           Period
 }
 
-// EmbeddedData defines component schema for EmbeddedData.
-type EmbeddedData struct {
-	ContentType string
-	Data        string
+// DocumentReference defines component schema for DocumentReference.
+type DocumentReference struct {
+	ID          string
+	Title       string
+	ContentType *string
+	URL         *string
+	Hash        *string
 }
 
 // Period defines component schema for Period.

--- a/test-data/valid-consent.json
+++ b/test-data/valid-consent.json
@@ -43,7 +43,10 @@
   ],
   "sourceAttachment": {
     "contentType": "application/pdf",
-    "data": "dhklauHAELrlg78OLg=="
+    "hash": "hash",
+    "id": "id",
+    "title": "title",
+    "url": "https://some.url/reference.pdf"
   },
   "verification": [
     {
@@ -103,8 +106,12 @@
         ],
         "class": [
           {
-            "system": "http://hl7.org/fhir/resource-types",
-            "code": "Observation"
+            "system": "urn:oid:1.3.6.1.4.1.XXXXX.1",
+            "code": "MEDICAL"
+          },
+          {
+            "system": "urn:oid:1.3.6.1.4.1.XXXXX.1",
+            "code": "SOCIAL"
           }
         ]
       }


### PR DESCRIPTION
required changes to remove all traces of personal data from the consent records.
If the proof is accessible via a REST call with Nuts authentication a viewer can verify its contents.

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>