### PR TITLE
Fixed consent record signatures checking to check against all org keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/nuts-foundation/nuts-event-octopus v0.13.0
 	github.com/nuts-foundation/nuts-fhir-validation v0.13.0
 	github.com/nuts-foundation/nuts-go-core v0.13.0
-	github.com/nuts-foundation/nuts-registry v0.13.3-0.20200404095034-2c1f0150eff0
+	github.com/nuts-foundation/nuts-registry v0.13.5
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cobra v0.0.7

--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,11 @@ require (
 	github.com/lestrrat-go/jwx v0.9.1
 	github.com/nuts-foundation/consent-bridge-go-client v0.13.0
 	github.com/nuts-foundation/nuts-consent-store v0.13.0
-	github.com/nuts-foundation/nuts-crypto v0.13.0
+	github.com/nuts-foundation/nuts-crypto v0.13.2
 	github.com/nuts-foundation/nuts-event-octopus v0.13.0
 	github.com/nuts-foundation/nuts-fhir-validation v0.13.0
 	github.com/nuts-foundation/nuts-go-core v0.13.0
-	github.com/nuts-foundation/nuts-registry v0.13.1
+	github.com/nuts-foundation/nuts-registry v0.13.3-0.20200404095034-2c1f0150eff0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,9 @@ github.com/nuts-foundation/nuts-consent-store v0.13.0 h1:ufj2fZY7i48tkex1Q48zreh
 github.com/nuts-foundation/nuts-consent-store v0.13.0/go.mod h1:Xt4taVtQPmV1u6KxceSiQRkkQVZlN6jyYnIu03flYZY=
 github.com/nuts-foundation/nuts-crypto v0.13.0 h1:szSHnYpK+0ORHNpeBdhPocVoukp9oxZWowKF4YCaPlI=
 github.com/nuts-foundation/nuts-crypto v0.13.0/go.mod h1:2JTdNvxWBbqv/VWQw3PazNNjY4FlbDf6LAyv2u2vtGo=
+github.com/nuts-foundation/nuts-crypto v0.13.1-0.20200402090327-2ec6f557b445/go.mod h1:A+8TA3p+b73Bc1Hx8TFods389I3hWmJ9oXMtS7KE1w0=
+github.com/nuts-foundation/nuts-crypto v0.13.2 h1:BoQ8qCILtEuC+firfYOIiZocLU5WO7RK5gyYTsZVSF0=
+github.com/nuts-foundation/nuts-crypto v0.13.2/go.mod h1:2JTdNvxWBbqv/VWQw3PazNNjY4FlbDf6LAyv2u2vtGo=
 github.com/nuts-foundation/nuts-event-octopus v0.13.0 h1:nTSpWUhgwc/YmnsIgqK8L8hB2TzYj3d1Z1ss3lrwoe4=
 github.com/nuts-foundation/nuts-event-octopus v0.13.0/go.mod h1:zVNeYF75YcHjRfycY4OjQObjJ1HaqZpGft7BiSDT/8E=
 github.com/nuts-foundation/nuts-fhir-validation v0.13.0 h1:Qjdyc2cHaW1sB2jp4DGJdDsy67+8Y5VhLgFk//cRGWw=
@@ -370,6 +373,10 @@ github.com/nuts-foundation/nuts-registry v0.13.0 h1:PacqLjYbzuA5pTETINqmuwqj3fUM
 github.com/nuts-foundation/nuts-registry v0.13.0/go.mod h1:rqHcXmi4Rj51s7peXot/ZjldQNRvSpWoNS2heJrRAqc=
 github.com/nuts-foundation/nuts-registry v0.13.1 h1:gRWq54cYC/EaniPkbGYEupXcZRbzxjYATZeNgK/sUws=
 github.com/nuts-foundation/nuts-registry v0.13.1/go.mod h1:rqHcXmi4Rj51s7peXot/ZjldQNRvSpWoNS2heJrRAqc=
+github.com/nuts-foundation/nuts-registry v0.13.3-0.20200404095034-2c1f0150eff0 h1:ENa4RKt0M5WmRRLvGxDVQ2AbFYhIGBYRQROLS1LpdNo=
+github.com/nuts-foundation/nuts-registry v0.13.3-0.20200404095034-2c1f0150eff0/go.mod h1:MZRLBtlzLBLlVUUBPDCXOvH7Djom0JM4vNZt706C5Vk=
+github.com/nuts-foundation/nuts-registry v0.13.4 h1:vhOHXKegYuhVfcY9/bUXqowsmwYQr2o5gLH3iO4c5JU=
+github.com/nuts-foundation/nuts-registry v0.13.4/go.mod h1:ktTP8nbHEiE8yOxV5NcyDyZ84IG/RdBbLME0D+EpCcE=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,8 @@ github.com/nuts-foundation/nuts-registry v0.13.3-0.20200404095034-2c1f0150eff0 h
 github.com/nuts-foundation/nuts-registry v0.13.3-0.20200404095034-2c1f0150eff0/go.mod h1:MZRLBtlzLBLlVUUBPDCXOvH7Djom0JM4vNZt706C5Vk=
 github.com/nuts-foundation/nuts-registry v0.13.4 h1:vhOHXKegYuhVfcY9/bUXqowsmwYQr2o5gLH3iO4c5JU=
 github.com/nuts-foundation/nuts-registry v0.13.4/go.mod h1:ktTP8nbHEiE8yOxV5NcyDyZ84IG/RdBbLME0D+EpCcE=
+github.com/nuts-foundation/nuts-registry v0.13.5 h1:+rP1ApnZ8s/Env3URvCcYJZ7LXa54d+amKEmcJC+FUk=
+github.com/nuts-foundation/nuts-registry v0.13.5/go.mod h1:ktTP8nbHEiE8yOxV5NcyDyZ84IG/RdBbLME0D+EpCcE=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Fixes #43 

Fixed consent record signatures checking to check against all org keys, instead of deprecated Organization.PublicKey

Now verifies the signature's public key against all keys of the signing organization.